### PR TITLE
not able to print mint event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,31 @@ pub extern "C" fn map_hello_world(block_ptr: *mut u8, block_len: usize) {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn map_mint(block_ptr: *mut u8, block_len: usize) {
+    substreams::register_panic_hook();
+
+    let blk: pb::eth::Block = proto::decode_ptr(block_ptr, block_len).unwrap();
+
+    for trx in blk.transaction_traces {
+        for call in trx.calls {
+            for log in call.clone().logs {
+                // this is able to print
+                // if !utils::is_erc20transfer_event(&log) {
+                //     continue;
+                // }
+
+                // however this is not able to print. why?
+                if !utils::is_mint_event(&log) {
+                    continue;
+                }
+                substreams::output(utils::address_pretty(trx.hash.as_slice()));
+                return;
+            }
+        }
+    }
+}
+
 /// Find and output all the ERC20 transfers
 ///
 /// `block_ptr`: Pointer of where the block is located in the wasm heap memory

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,14 @@ pub fn is_erc20transfer_event(log: &pb::eth::Log) -> bool {
     return hex::encode(&log.topics[0]) == TRANSFER_TOPIC;
 }
 
+pub fn is_mint_event(log: &pb::eth::Log) -> bool {
+    if log.topics.len() != 3 || log.data.len() != 32 {
+        return false;
+    }
+    // keccak Mint(address,uint256,uint256)
+    return hex::encode(&log.topics[0]) == "4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f";
+}
+
 /// Find the erc20 storage changes (new and old valance of given holder)
 ///
 /// `call`: Call containing storage changes

--- a/substream.yaml
+++ b/substream.yaml
@@ -14,6 +14,19 @@ modules:
     output:
       type: proto:sf.ethereum.type.v1.TransactionTrace
 
+  - name: handle_mint
+    kind: map
+    startBlock: 9475627
+    code:
+      type: wasm/rust-v1
+      file: ./target/wasm32-unknown-unknown/release/substreams_template.wasm
+      entrypoint: map_mint
+    inputs:
+      - source: sf.ethereum.type.v1.Block
+    output:
+      type: String
+
+
   - name: block_to_erc_20_transfer
     kind: map
     startBlock: 14440000


### PR DESCRIPTION
i confirm block 9475627 has Mint event https://etherscan.io/tx/0x000015265699f4b95f313b600697ced18ce9c597454a327471095ef541734da6#eventlog

however it doesn't print as expected. why?

To reproduce:

```
substreams run -e api-dev.streamingfast.io:443 substream.yaml handle_mint
```